### PR TITLE
Allow connections that do not contain accept header

### DIFF
--- a/src/AcceptFilterListener.php
+++ b/src/AcceptFilterListener.php
@@ -67,7 +67,7 @@ class AcceptFilterListener extends ContentTypeFilterListener
     protected function validateMediaType($match, HttpHeaders $headers)
     {
         if (!$headers->has('accept')) {
-            return false;
+            return true;
         }
 
         $accept = $headers->get('accept');


### PR DESCRIPTION
Updated accept filter to allow connections that do not contain the accept header field. This causes issues with integrating with some services such as GitLab and also does not follow the W3C recommendation.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
Under 14.1: “If no Accept header field is present, then it is assumed that the client accepts all media types. If an Accept header field is present, and if the server cannot send a response which is acceptable according to the combined Accept field value, then the server SHOULD send a 406 (not acceptable) response."